### PR TITLE
Validate session storage entries

### DIFF
--- a/src/browser/SessionStorageCacheMap.ts
+++ b/src/browser/SessionStorageCacheMap.ts
@@ -245,7 +245,11 @@ export class SessionStorageCacheMap<
 
         try {
           const parsed = JSON.parse(stored);
-          if (parsed.originalKey) {
+          if (
+            parsed.originalKey &&
+            parsed.originalVerificationHash &&
+            this.verificationHashFunction(parsed.originalKey) === parsed.originalVerificationHash
+          ) {
             keys.push(parsed.originalKey);
           }
         } catch (itemError) {
@@ -271,7 +275,12 @@ export class SessionStorageCacheMap<
 
         try {
           const parsed = JSON.parse(stored);
-          if (parsed.value != null) {
+          if (
+            parsed.value != null &&
+            parsed.originalKey &&
+            parsed.originalVerificationHash &&
+            this.verificationHashFunction(parsed.originalKey) === parsed.originalVerificationHash
+          ) {
             values.push(parsed.value);
           }
         } catch (itemError) {


### PR DESCRIPTION
## Summary
- validate original key and verification hash before returning sessionStorage keys
- ensure values method only returns entries with matching verification hash

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898de83f3a0832590b43c72dbd4d6ba